### PR TITLE
chore(config): correct default port

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo-local-faucet",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A dockerized, nodejs version of neo-faucet",
   "main": "server.js",
   "scripts": {

--- a/src/server/variables.js
+++ b/src/server/variables.js
@@ -9,7 +9,7 @@ export const faucet = new wallet.Account(
 );
 
 export const faucetAddress = process.env.FAUCET_ADDRESS || "localhost";
-export const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 4020;
+export const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 4002;
 export const neoReward = process.env.NEO_REWARD || 100;
 export const gasReward = process.env.GAS_REWARD || 2000;
 export const underRewardAmount = process.env.UNDER_REWARD_AMOUNT


### PR DESCRIPTION
Fixes the fact that it wouldn't run on default config (docker says 4002, port in config says 4020)

## Proposed Changes

- Changed default port back to 4002
